### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=intorobot team
 maintainer=intorobot <support@intorobot.cc>
 sentence=connect to intorobot cloud.
 paragraph=The IntoRobot library feature: through the library, you can connect the device through the IntoRobot Cloud.
+category=Device Control
 url=*
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library IntoRobot is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format