### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,13 +13,13 @@ IntorobotClass	KEYWORD3
 #######################################
 
 connected	KEYWORD2
-connect     KEYWORD2
+connect	KEYWORD2
 disconnect	KEYWORD2
-publish     KEYWORD2
+publish	KEYWORD2
 subscribe	KEYWORD2
 unsubscribe	KEYWORD2
 deviceInfo	KEYWORD2
-process     KEYWORD2
+process	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords